### PR TITLE
Loading plugin textdomain path fix

### DIFF
--- a/widget-boilerplate/plugin.php
+++ b/widget-boilerplate/plugin.php
@@ -195,7 +195,7 @@ class Widget_Name extends WP_Widget {
 	public function widget_textdomain() {
 
 		// TODO be sure to change 'widget-name' to the name of *your* plugin
-		load_plugin_textdomain( $this->get_widget_slug(), false, plugin_dir_path( __FILE__ ) . 'lang/' );
+		load_plugin_textdomain( $this->get_widget_slug(), false, dirname( plugin_basename( __FILE__ ) ) . 'lang/' );
 
 	} // end widget_textdomain
 


### PR DESCRIPTION
The relative path provided didn't load the required .mo file into the system, this change fixed it.